### PR TITLE
Allow replacing files in local file server

### DIFF
--- a/source/src/main/java/nl/aerius/fileserver/local/LocalFileStorageSevice.java
+++ b/source/src/main/java/nl/aerius/fileserver/local/LocalFileStorageSevice.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -60,7 +61,7 @@ class LocalFileStorageSevice implements StorageService {
       Files.createDirectory(uuidPath);
     }
     final File file = filePath(uuidPath, filename);
-    Files.copy(in, file.toPath());
+    Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
   }
 
   @Override


### PR DESCRIPTION
As it was, re-uploading a file with same ID/name would trigger an exception in local file server, while it wouldn't in the S3 implementation (as far as I can tell). Would like to be able to replace files for the async validation proces in Register.