### PR TITLE
[S3] Use `DefaultCredentialsProvider`

### DIFF
--- a/source/file-server/src/main/java/nl/aerius/fileserver/s3/S3ClientFactory.java
+++ b/source/file-server/src/main/java/nl/aerius/fileserver/s3/S3ClientFactory.java
@@ -20,7 +20,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 
-import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -37,7 +37,7 @@ class S3ClientFactory {
   public S3Client s3Client() {
     return S3Client.builder()
         .region(Region.of(System.getenv(SdkSystemSetting.AWS_REGION.environmentVariable())))
-        .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+        .credentialsProvider(DefaultCredentialsProvider.builder().build())
         .build();
   }
 


### PR DESCRIPTION
We want to be able to use other means of getting the credentials. Now ENV variables are enforced, which do work, but doesn't work if instance profile or Task Roles are used.