### PR TITLE
[local] Write files atomically to avoid 500s on concurrent reads

### DIFF
--- a/source/file-server/src/main/java/nl/aerius/fileserver/local/LocalFileStorageSevice.java
+++ b/source/file-server/src/main/java/nl/aerius/fileserver/local/LocalFileStorageSevice.java
@@ -66,7 +66,17 @@ class LocalFileStorageSevice implements StorageService {
       Files.createDirectory(uuidPath);
     }
     final Path file = filePath(uuidPath, filename);
-    Files.copy(in, file, StandardCopyOption.REPLACE_EXISTING);
+    // Write to a temporary file in the same directory and then atomically move it into place. A plain
+    // Files.copy(REPLACE_EXISTING) deletes the target before recreating it, which exposes a window where a
+    // concurrent read sees the file missing or partially written and fails with a 500. ATOMIC_MOVE (a rename)
+    // ensures readers always observe either the complete old file or the complete new one.
+    final Path tempFile = Files.createTempFile(uuidPath, filename + ".", ".tmp");
+    try {
+      Files.copy(in, tempFile, StandardCopyOption.REPLACE_EXISTING);
+      Files.move(tempFile, file, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+    } finally {
+      Files.deleteIfExists(tempFile);
+    }
   }
 
   @Override

--- a/source/file-server/src/test/java/nl/aerius/fileserver/local/LocalFileStorageSeviceTest.java
+++ b/source/file-server/src/test/java/nl/aerius/fileserver/local/LocalFileStorageSeviceTest.java
@@ -16,6 +16,7 @@
  */
 package nl.aerius.fileserver.local;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -80,6 +81,16 @@ class LocalFileStorageSeviceTest {
     service.putFile(UUID_CODE, FILENAME, 0, null, new ByteArrayInputStream(overwriteContent.getBytes()));
     assertTrue(expectedFile.exists(), "File should exist when stored twice");
     assertEquals(overwriteContent, Files.readString(expectedFile.toPath()), "Content of file should be as expected.");
+  }
+
+  @Test
+  void testPutFileLeavesNoTempFile() throws IOException {
+    // The atomic-write path stages the content in a temp file before moving it into place; ensure that
+    // temp file is always cleaned up so it can't leak into directory listings or repeated overwrites.
+    service.putFile(UUID_CODE, FILENAME, 10, null, new ByteArrayInputStream(CONTENT.getBytes()));
+    service.putFile(UUID_CODE, FILENAME, 0, null, new ByteArrayInputStream(CONTENT.getBytes()));
+    final String[] storedFiles = expectedFile.getParentFile().list();
+    assertArrayEquals(new String[] {FILENAME}, storedFiles, "Only the target file should remain, no temp residue.");
   }
 
   @Test


### PR DESCRIPTION
The file-server intermittently returns HTTP 500 on GET of a stored file when the same file is overwritten while it is being read.

Root cause: LocalFileStorageSevice.putFile used Files.copy(in, file, REPLACE_EXISTING), which is not atomic. The JDK implementation deletes the target and then recreates it (CREATE_NEW) before streaming the bytes, so during an overwrite the file briefly does not exist. LocalFileController.getFile checks existence and returns a FileUrlResource, but the read and contentLength() happen afterwards, when Spring's ResourceHttpMessageConverter serializes the body, outside the controller's try/catch. If the writer's delete lands in that window, contentLength() throws FileNotFoundException, which escapes to the dispatcherServlet as a 500.

This surfaced in Register: on upload the API writes validation.json twice (a pending result, then the real result) while the frontend polls the validation-result endpoint in a tight loop, so overwrites overlap live reads. A single 500 there makes the upload fail for the user. Only the local storage profile is affected; the s3 profile redirects to an S3 URL and S3 overwrites are atomic.

Fix: stage the content in a temp file in the same directory and ATOMIC_MOVE it into place, so a concurrent reader always sees either the complete old file or the complete new one.

Reproduction, 8 concurrent readers and one writer overwriting for 3s:
  non-atomic copy: 339751 reads failed with FileNotFoundException (each a 500)
  atomic move:     0 failures